### PR TITLE
Updating notebooks, adding crosslinks in KFServing chapter.

### DIFF
--- a/Research/kubeflow-on-azure-stack-lab/04-KFServing/Readme.md
+++ b/Research/kubeflow-on-azure-stack-lab/04-KFServing/Readme.md
@@ -68,14 +68,38 @@ You would need to manually label your particular namespace with `inferenceservic
 
 You might also need to resolve the access issues, see [Kubernetes documentation](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) or [KFServing Troubleshooting](https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md#troubleshooting).
 
+---
+
 ## Infrerencing using KFServing
 
-We created separate demos for
+---
 
- - [KFServing TensorFlow models](tensorflow.md)
- - [KFServing PyTorch models](pytorch.md)
+### KFServing TensorFlow models
 
-Here we will walk through a demo for SKLearn.
+Please see a separate sub-page, [KFServing TensorFlow models](tensorflow.md)
+
+---
+
+### KFServing PyTorch models
+
+You can validate PyTorch models using PyTorch cli before deploying.
+
+Please see a separate sub-page, [KFServing PyTorch models](pytorch.md)
+ 
+---
+
+### KFServing models saved in ONNX format
+
+ONNX is an ecosystem that could contain models from different frameworks and custom
+action blocks.
+
+Please see a separate sub-page, [KFServing models saved in ONNX format](onnx.md)
+
+---
+
+### KFServing model SKLearn Iris model
+
+Let us walk through a demo for SKLearn, which is similar for other ML frameworks.
 
 To create KFServing inference service, you can try a sample from [kfserving repository](https://github.com/kubeflow/kfserving):
 

--- a/Research/kubeflow-on-azure-stack-lab/04-KFServing/onnx-mosaic.ipynb
+++ b/Research/kubeflow-on-azure-stack-lab/04-KFServing/onnx-mosaic.ipynb
@@ -32,7 +32,7 @@
     }
    ],
    "source": [
-    "!pip install pillow --user"
+    "!pip install pillow jupyter numpy protobuf requests --user"
    ]
   },
   {
@@ -155,6 +155,13 @@
    ]
   },
   {
+   "source": [
+    "The POST request we construct and send may timeout because `inferenceservice` creates pods on demand and the latency for the response might be substantial(a minute or more). If you receive an error message, try re-running the next cell. In case of success you should receive the http response code 200."
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 48,
    "metadata": {},
@@ -225,9 +232,13 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
+   "name": "Python 3.8.6 64-bit",
+   "display_name": "Python 3.8.6 64-bit",
+   "metadata": {
+    "interpreter": {
+     "hash": "39125b5409e0292efda8286b395f6798cb9e5762b6be52e7612d25cf7547bdfe"
+    }
+   }
   },
   "language_info": {
    "codemirror_mode": {
@@ -239,7 +250,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.8.6-final"
   }
  },
  "nbformat": 4,

--- a/Research/kubeflow-on-azure-stack-lab/04-KFServing/pytorch.md
+++ b/Research/kubeflow-on-azure-stack-lab/04-KFServing/pytorch.md
@@ -156,4 +156,6 @@ For troubleshooting, see [Kubeflow website](https://github.com/kubeflow/kfservin
 
 - https://github.com/kubeflow/kfserving/tree/master/docs/samples/pytorch
 
+---
+
 [Back](Readme.md)

--- a/Research/kubeflow-on-azure-stack-lab/04-KFServing/tensorflow.md
+++ b/Research/kubeflow-on-azure-stack-lab/04-KFServing/tensorflow.md
@@ -227,4 +227,6 @@ See `tensorflow_web_infer.py` for example of how to pick the right index and get
 - https://www.tensorflow.org/tfx/serving/api_rest
 - https://www.tensorflow.org/tfx/tutorials/serving/rest_simple
 
+---
+
 [Back](Readme.md)

--- a/machine-learning-notebooks/deploying-on-k8s/production-deploy-to-k8s-gpu.ipynb
+++ b/machine-learning-notebooks/deploying-on-k8s/production-deploy-to-k8s-gpu.ipynb
@@ -35,7 +35,7 @@
    "outputs": [],
    "source": [
     "#upgrade to latest versionof sdk \n",
-    "!pip install --upgrade azureml-sdk"
+    "!pip install --upgrade azureml-sdk --user"
    ]
   },
   {


### PR DESCRIPTION
## Purpose
* Linking ONNX page to main README for KFServing (Research/kubeflow-on-azurestack/04-KFServing)
* Updates for demo notebooks, addressing prerequisites, expanding explanation.

## Does this introduce a breaking change?
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[X] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
Follow the documentation at `Research/kubeflow-on-azurestack/04-KFServing`
```
```

## What to Check
Verify that the following are valid
* notebooks from KFServing chapter should run in Kubeflow we instantiate in `Research/kubeflow-on-azurestack/00_intro`

## Other Information
