### PR TITLE
Updating Kubeflow install package version to 1.2

### DIFF
--- a/Research/kubeflow-on-azure-stack-lab/00-Intro/porter/kubeflow/porter.yaml
+++ b/Research/kubeflow-on-azure-stack-lab/00-Intro/porter/kubeflow/porter.yaml
@@ -33,22 +33,26 @@ parameters:
   - name: kfctl_release_filename
     type: string
     #default: "kfctl_v1.0.2-0-ga476281_linux.tar.gz"
-    default: "kfctl_v1.1.0-0-g9a3621e_linux.tar.gz"
+    #default: "kfctl_v1.1.0-0-g9a3621e_linux.tar.gz"
+    default: "kfctl_v1.2-rc.2-0-g1316754_linux.tar.gz"
 
   - name: kfctl_release_uri
     type: string
     #default: "https://github.com/kubeflow/kfctl/releases/download/v1.0.2/kfctl_v1.0.2-0-ga476281_linux.tar.gz"
-    default: "https://github.com/kubeflow/kfctl/releases/download/v1.1.0/kfctl_v1.1.0-0-g9a3621e_linux.tar.gz"
+    #default: "https://github.com/kubeflow/kfctl/releases/download/v1.1.0/kfctl_v1.1.0-0-g9a3621e_linux.tar.gz"
+    default: "https://github.com/kubeflow/kfctl/releases/download/v1.2-rc.2/kfctl_v1.2-rc.2-0-g1316754_linux.tar.gz"
 
   - name: kf_config_filename
     type: string
     #default: "kfctl_k8s_istio.v1.0.2.yaml"
-    default: "kfctl_k8s_istio.v1.1.0.yaml"
+    #default: "kfctl_k8s_istio.v1.1.0.yaml"
+    default: "kfctl_k8s_istio.v1.2.0.yaml"
     
   - name: kf_config_uri
     type: string
     #default: "https://raw.githubusercontent.com/kubeflow/manifests/v1.1-branch/kfdef/kfctl_k8s_istio.v1.0.2.yaml"
-    default: "https://raw.githubusercontent.com/kubeflow/manifests/v1.1-branch/kfdef/kfctl_k8s_istio.v1.1.0.yaml"
+    #default: "https://raw.githubusercontent.com/kubeflow/manifests/v1.1-branch/kfdef/kfctl_k8s_istio.v1.1.0.yaml"
+    default: "https://raw.githubusercontent.com/kubeflow/manifests/v1.2-branch/kfdef/kfctl_k8s_istio.v1.2.0.yaml"
 
 credentials:
   - name: kubeconfig


### PR DESCRIPTION
## Purpose
* This PR updates the manifest versions to deploy Kubeflow 1.2 with KFServing 0.4.1

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
Follow the instructions in `Research/kubeflow-on-azure-stack-lab/00-Intro`
```
```

## What to Check
Verify that the following are valid
* That you can deploy a Kubeflow cluster and the version match

## Other Information
