### PR TITLE
Updating Kubeflow manual install instructions and scripts

### DIFF
--- a/Research/kubeflow-on-azure-stack-lab/00-Intro/installing_kubeflow_manually.md
+++ b/Research/kubeflow-on-azure-stack-lab/00-Intro/installing_kubeflow_manually.md
@@ -132,17 +132,32 @@ Download the `kfctl` from [Kubeflow releases](https://github.com/kubeflow/kfctl/
 
     $ mkdir kubeflow
     $ cd kubeflow/
+
+There could be some version nuances, we are giving you v1.1 and v1.2-rc, but for the very latest,
+or required by your application or operaor, see [Kubeflow website](https://www.kubeflow.org/)
+
+v1.1:
+
     $ wget https://github.com/kubeflow/kfctl/releases/download/v1.1.0/kfctl_v1.1.0-0-ga776281_linux.tar.gz
     ...
     ‘kfctl_v1.1.0-0-gf9edb9b_linux.tar.gz’ saved [31630869/31630869]
-
     $ tar -xvf kfctl_v1.1.0-0-gf7edb9b_linux.tar.gz
+    $ export CONFIG_URI="https://raw.githubusercontent.com/kubeflow/manifests/v1.1-branch/kfdef/kfctl_k8s_istio.v1.1.0.yaml"
+
+v1.2-rc:
+
+    $ wget https://github.com/kubeflow/kfctl/releases/download/v1.2-rc.2/kfctl_v1.2-rc.2-0-g1316754_linux.tar.gz
+    ...
+    ‘kfctl_v1.2-rc.2-0-g1316754_linux.tar.gz’ saved [31630869/31630869]
+    $ tar -xvf kfctl_v1.2-rc.2-0-g1316754_linux.tar.gz
+    $ export CONFIG_URI="https://raw.githubusercontent.com/kubeflow/manifests/v1.2-branch/kfdef/kfctl_k8s_istio.v1.2.0.yaml"
+
+The rest of configuration is the same, and you are encouraged to pick a unique name for your cluster(instead `sandboxASkf`):
 
     $ export PATH=$PATH:~/kubeflow/
     $ export KF_NAME=sandboxASkf
     $ export BASE_DIR=/opt/
     $ export KF_DIR=${BASE_DIR}/${KF_NAME}
-    $ export CONFIG_URI="https://raw.githubusercontent.com/kubeflow/manifests/v1.1-branch/kfdef/kfctl_k8s_istio.v1.1.0.yaml"
     
 Generate and deploy Kubeflow:
 

--- a/Research/kubeflow-on-azure-stack-lab/03-PyTorchJobs/Readme.md
+++ b/Research/kubeflow-on-azure-stack-lab/03-PyTorchJobs/Readme.md
@@ -41,7 +41,7 @@ There is a suitable verion of the container we could use, `kubeflow/pytorch-dist
 If you would like to build your own, to create a container image for thisPyTorch implementation of
 `mnist` test, use the `Dockerfile` provided in `docker` subfolder:
 
-    $ cd Research/kubeflow-on-azure-stack/pytorch-on-kubeflow/docker
+    $ cd Research/kubeflow-on-azure-stack-lab/03-PyTorchJobs/docker
 
 Login to your Docker account:
 
@@ -272,7 +272,7 @@ Here is a sample of the output:
     Train Epoch: 1 [59520/60000 (99%)]      loss=0.0645
     accuracy=0.9666
 
-If you mounted the persistent storage to your cluster as described in [Installing Storage](../installing_storage.md), you can attach it to your `PyTorchJob`(i.e. using provided .yaml):
+If you mounted the persistent storage to your cluster as described in [Installing Storage](../01-Jupyter/installing_storage.md), you can attach it to your `PyTorchJob`(i.e. using provided .yaml):
 
     $ kubectl create -f pytorch_job_mnist_gloo_demo-with-persistence.yaml
     pytorchjob.kubeflow.org/pytorch-dist-mnist-gloo-demo created

--- a/Research/kubeflow-on-azure-stack-lab/sbin/kubeflow_install.sh
+++ b/Research/kubeflow-on-azure-stack-lab/sbin/kubeflow_install.sh
@@ -10,16 +10,21 @@ export KF_CTL_DIR=~/kubeflow/
 export KF_NAME=sandboxASkf
 export KF_USERNAME=azureuser
 
-export KFCTL_RELEASE_FILENAME=kfctl_v1.1.0-0-g9a3621e_linux.tar.gz
-export KFCTL_RELEASE_URI="https://github.com/kubeflow/kfctl/releases/download/v1.1.0/${KFCTL_RELEASE_FILENAME}"
 #export KFCTL_RELEASE_FILENAME=kfctl_v1.0.2-0-ga476281_linux.tar.gz
 #export KFCTL_RELEASE_URI="https://github.com/kubeflow/kfctl/releases/download/v1.0.2/${KFCTL_RELEASE_FILENAME}"
+#export KFCTL_RELEASE_FILENAME=kfctl_v1.1.0-0-g9a3621e_linux.tar.gz
+#export KFCTL_RELEASE_URI="https://github.com/kubeflow/kfctl/releases/download/v1.1.0/${KFCTL_RELEASE_FILENAME}"
+export KFCTL_RELEASE_FILENAME=kfctl_v1.2-rc.2-0-g1316754_linux.tar.gz
+export KFCTL_RELEASE_URI="https://github.com/kubeflow/kfctl/releases/download/v1.2-rc.2/${KFCTL_RELEASE_FILENAME}"
 
 export KF_DIR_BASE=/opt
 
-export KF_CONFIG_FILENAME="kfctl_k8s_istio.v1.1.0.yaml"
-#export KF_CONFIG_FILENAME="kfctl_k8s_istio.v1.0.2.yaml"
-export KF_CONFIG_URI="https://raw.githubusercontent.com/kubeflow/manifests/v1.1-branch/kfdef/${KF_CONFIG_FILENAME}"
+#export KF_CONFIG_FILENAME="kfctl_k8s_istio.v1.1.0.yaml"
+##export KF_CONFIG_FILENAME="kfctl_k8s_istio.v1.0.2.yaml"
+#export KF_CONFIG_URI="https://raw.githubusercontent.com/kubeflow/manifests/v1.1-branch/kfdef/${KF_CONFIG_FILENAME}"
+export KF_CONFIG_FILENAME="kfctl_k8s_istio.v1.2.0.yaml"
+export KF_CONFIG_URI="https://raw.githubusercontent.com/kubeflow/manifests/v1.2-branch/kfdef/${KF_CONFIG_FILENAME}"
+
 
 export DO_UNATTENDED=0
 


### PR DESCRIPTION
## Purpose
* Updating Kubeflow manual install instructions and scripts to give option to install newer Kubeflow, 1.2
* Correcting documentation links in PyTorch chapter.

## Does this introduce a breaking change?
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
Follow the manual installation instructions as described in `Research/kubeflow-on-azure-stack-lab/00-Intro`
```
```

## What to Check
Verify that the following are valid
* You should be able to install a Kubeflow cluster with the version 1.2-rc and KFServing 0.4.1

## Other Information
<!-- Add any other helpful information that may be needed here. -->