### PR TITLE
Bug fix for setting threshold function in factory ai solution

### DIFF
--- a/factory-ai-vision/EdgeSolution/modules/InferenceModule/scenarios.py
+++ b/factory-ai-vision/EdgeSolution/modules/InferenceModule/scenarios.py
@@ -41,6 +41,9 @@ class PartDetection(Scenario):
         self.trackers = {}
         self.parts = []
 
+    def set_threshold(self, threshold):
+        self.threshold = threshold
+
     def set_parts(self, parts):
         self.parts = parts
         self.trackers = {}


### PR DESCRIPTION
## Purpose
* Bug fix for Factory AI InferenceModule - setting a threshold class function was missing in PartDetection.

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* InferenceModule doesn't throw errors on "set_threshold" function not being present in `iotedge logs inferencemodule`.

## Other Information
<!-- Add any other helpful information that may be needed here. -->